### PR TITLE
fix: update trivy-action from @master to @v0.35.0

### DIFF
--- a/.github/workflows/vulnerability-scanner.yml
+++ b/.github/workflows/vulnerability-scanner.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy scaner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           scan-type: 'fs'
           exit-code: '1'


### PR DESCRIPTION
## Summary

Pin `aquasecurity/trivy-action` from the floating `@master` tag to the stable `@v0.35.0` release.

## Changes

- `.github/workflows/vulnerability-scanner.yml`: `aquasecurity/trivy-action@master` → `aquasecurity/trivy-action@v0.35.0`

## Motivation

Using `@master` means the action can change at any time without notice, potentially breaking CI or introducing unexpected behavior. Pinning to a specific version ensures reproducible and predictable builds.

## Ticket

https://redmine.regulaforensics.com/issues/54074