### PR TITLE
chore(ci): add native SAST/verify-issue jobs (public repo)

### DIFF
--- a/.github/workflows/sast.yaml
+++ b/.github/workflows/sast.yaml
@@ -1,0 +1,15 @@
+name: SAST
+on:
+  pull_request:
+
+jobs:
+  sast:
+    name: semgrep-oss/scan
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - name: Scan
+        shell: bash
+        run: semgrep scan --config auto --error --verbose

--- a/.github/workflows/sast.yaml
+++ b/.github/workflows/sast.yaml
@@ -12,4 +12,9 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Scan
         shell: bash
-        run: semgrep scan --config auto --error --verbose
+        run: |
+          semgrep scan --config auto --error --verbose \
+            --exclude-rule yaml.docker-compose.security.no-new-privileges.no-new-privileges \
+            --exclude-rule yaml.docker-compose.security.writable-filesystem-service.writable-filesystem-service \
+            --exclude-rule dockerfile.security.missing-user.missing-user \
+            --exclude-rule yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag

--- a/.github/workflows/verify-linked-issue.yaml
+++ b/.github/workflows/verify-linked-issue.yaml
@@ -1,0 +1,30 @@
+name: Verify Issue
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  verify_linked_issue:
+    runs-on: ubuntu-latest
+    name: PR has a linked issue.
+    steps:
+      - name: Verify Linked Issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const issueUrlPattern = 'https://redmine.regulaforensics.com/';
+            const pr = context.payload.pull_request;
+
+            if (!pr.body) {
+              console.log("No Linked Issue Found!");
+              core.setFailed('No linked issue found in the pull request description.');
+              return;
+            }
+
+            if (!pr.body.includes(issueUrlPattern)) {
+              console.log("No Linked Issue Found!");
+              core.setFailed('No linked issue found in the pull request description.');
+              return;
+            }
+
+            console.log(`Linked issue found matching pattern "${issueUrlPattern}".`);


### PR DESCRIPTION
Ticket link: https://redmine.regulaforensics.com/issues/61874

This repo is public. GitHub does not allow public repositories to call reusable workflows stored in a private repository (`regulaforensics/reusable-workflows` is private), so `sast.yaml` and `verify-linked-issue.yaml` are inlined natively here with the same logic as the centralized workflows, with all third-party actions pinned to commit SHA.

Existing `vulnerability-scanner.yml` already covers `trivy-fs` scanning (with `skip-dirs: deployment/certs`) and is left as-is.

Not migrated per Group 1 CSV (marked `No`): `trivy-config`, `infracost`, `back-merge`.