### PR TITLE
Add renovate.json: weekly GitHub Actions PR + SHA pinning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["github-actions"],
+  "labels": ["dependencies", "github-actions"],
+  "prBodyNotes": ["Ticket link: https://redmine.regulaforensics.com/issues/58096"],
+  "packageRules": [
+    {
+      "description": "Group all GitHub Actions updates (including major) into a single weekly PR",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions",
+      "schedule": ["before 6am on monday"],
+      "automerge": false
+    },
+    {
+      "description": "Pin non-reusable GitHub Actions to commit SHA digests (regulaforensics/reusable-workflows excluded — private repo, digest cannot be resolved)",
+      "matchManagers": ["github-actions"],
+      "matchDepTypes": ["action"],
+      "matchPackageNames": ["!regulaforensics/reusable-workflows"],
+      "pinDigests": true
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,7 @@
       "matchManagers": ["github-actions"],
       "matchDepTypes": ["action"],
       "matchPackageNames": ["!regulaforensics/reusable-workflows"],
+      "minimumReleaseAge": false,
       "pinDigests": true
     }
   ]


### PR DESCRIPTION
Adds `renovate.json` so GitHub Actions updates are grouped into a single weekly PR (Monday) and non-reusable actions are pinned to commit SHA digests. `regulaforensics/reusable-workflows` is excluded from digest pinning since it's a private repo Renovate cannot resolve digests for.

Ticket: https://redmine.regulaforensics.com/issues/61874